### PR TITLE
Set gradle parameter with environmental variables (tag 1.0.11)

### DIFF
--- a/internal/app/commands/project/project.go
+++ b/internal/app/commands/project/project.go
@@ -92,9 +92,12 @@ func runGradleTask(projectData *common.ProjectData, message string, tasks ...str
 
 	sandboxData := sandbox.ReadSandboxData(projectData.Sandbox)
 
-	javaHome := fmt.Sprintf("-Dorg.gradle.java.home=%s", sandbox.GetDistroJdkPath(sandboxData.Distro))
-	xpHome := fmt.Sprintf("-Dxp.home=%s", sandbox.GetSandboxHomePath(projectData.Sandbox))
-	args := append(tasks, javaHome, xpHome)
+	javaHome := sandbox.GetDistroJdkPath(sandboxData.Distro)
+	xpHome := sandbox.GetSandboxHomePath(projectData.Sandbox)
+
+	javaHomeArg := fmt.Sprintf("-Dorg.gradle.java.home=%s", javaHome)
+	xpHomeArg := fmt.Sprintf("-Dxp.home=%s", xpHome)
+	args := append(tasks, javaHomeArg, xpHomeArg)
 
 	fmt.Fprintln(os.Stderr, message)
 
@@ -103,6 +106,9 @@ func runGradleTask(projectData *common.ProjectData, message string, tasks ...str
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("JAVA_HOME=%s", javaHome))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("XP_HOME=%s", xpHome))
 
 	cmd.Run()
 }


### PR DESCRIPTION
Same PR as #164 but changes applied to tag 1.0.11.

Everything still works as expected on Linux.

Original PR text:

Because the `./gradlew` script uses the env variable `$JAVA_HOME` to set the java binary location, not the `-Dorg.gradle.java.home` parameter, I changed how we called it.

Now it uses the env variables for `JAVA_HOME` and `XP_HOME`. This fixes the issue on Linux when the Snap complained about an invalid `$JAVA_HOME`.  Now when running `enonic project deploy` it uses the distribution rather than Java installed on the machine.

This has been tested on Linux (running bash) and it worked. I have not tested this on Window, Cygwin (Windows) or Mac (Although it should work for bash on macs aswell).