### PR TITLE
Add install script for easy install on all Linux distros

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# This script is meant for quick & easy install via:
+#   $ wget -qO- https://raw.githubusercontent.com/enonic/cli-enonic/master/install.sh | sh
+
+set -ex
+
+# Set tmp variables
+tmp_dir=$(mktemp -d -t enonic-XXXXXXXXXX)
+tmp_archive=$tmp_dir/enonic.tar.gz
+
+# Download and unzip cli
+wget -qO- https://api.github.com/repos/enonic/cli-enonic/releases/latest \
+    | grep -o "https.*Linux_64-bit.tar.gz" \
+    | xargs -I {} wget {} -O $tmp_archive
+tar xvzf $tmp_archive -C $tmp_dir
+
+# Install cli
+sudo -k install $tmp_dir/enonic /usr/bin/enonic
+
+# Clean Up
+rm -r $tmp_dir


### PR DESCRIPTION
Seeing as we are having so much trouble with snapcraft. Here is a script that installs the CLI on all linux distros. You can try it out by simply opening a terminal (running linux) and running this one liner:

```bash
wget -qO- https://raw.githubusercontent.com/enonic/cli-enonic/install_script/install.sh | sh
```