### PR TITLE
Clean stacktraces on production releases #252

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,12 @@ builds:
     goarch:
       - amd64
 
+    gcflags:
+      - -trimpath={{ .Env.PWD }}
+
+    asmflags:
+      - -trimpath={{ .Env.PWD }}
+
     hooks:
       post: chmod 755 ./dist/enonic_darwin_amd64/enonic ./dist/enonic_linux_amd64/enonic
 


### PR DESCRIPTION
I dont know if the PWD env varible is available on windows. You might have to set it before building.