### PR TITLE
Enable global no-prompts flag #186

### DIFF
--- a/internal/app/commands/app/install.go
+++ b/internal/app/commands/app/install.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/enonic/cli-enonic/internal/app/commands/common"
 	"github.com/enonic/cli-enonic/internal/app/util"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"io"
 	"mime/multipart"
@@ -30,7 +31,7 @@ var Install = cli.Command{
 			Name:  "file, f",
 			Usage: "Application file",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		file, url := ensureURLOrFileFlag(c)
@@ -78,25 +79,32 @@ func ensureURLOrFileFlag(c *cli.Context) (string, string) {
 }
 
 func ensureURLFlag(c *cli.Context) string {
-	return util.PromptUntilTrue(c.String("u"), func(val *string, ind byte) string {
-		if len(strings.TrimSpace(*val)) == 0 {
-			switch ind {
-			case 0:
-				return "Enter URL: "
-			default:
-				return "URL can not be empty: "
+	force := common.IsForceMode(c)
+	urlValidator := func(val interface{}) error {
+		str := val.(string)
+		if len(strings.TrimSpace(str)) == 0 {
+			if force {
+				fmt.Fprintln(os.Stderr, "URL can not be empty in non-interactive mode.")
+				os.Exit(1)
 			}
+			return errors.New("URL can not be empty")
 		} else {
-			if _, err := url.ParseRequestURI(*val); err != nil {
-				return fmt.Sprintf("URL '%s' is not valid: ", *val)
+			if _, err := url.ParseRequestURI(str); err != nil {
+				if force {
+					fmt.Fprintf(os.Stderr, "URL '%s' is not valid", str)
+					os.Exit(1)
+				}
+				return errors.Errorf("URL '%s' is not valid: ", str)
 			}
-			return ""
+			return nil
 		}
-	})
+	}
+
+	return util.PromptString("Enter URL", c.String("u"), "", urlValidator)
 }
 
 func ensureFileFlag(c *cli.Context) string {
-	return util.PromptProjectJar(c.String("f"))
+	return util.PromptProjectJar(c.String("f"), common.IsForceMode(c))
 }
 
 func createInstallRequest(c *cli.Context, filePath, urlParam string) *http.Request {

--- a/internal/app/commands/cloud/project/deploy.go
+++ b/internal/app/commands/cloud/project/deploy.go
@@ -9,6 +9,7 @@ import (
 	multipart "github.com/enonic/cli-enonic/internal/app/commands/cloud/client"
 	mutations "github.com/enonic/cli-enonic/internal/app/commands/cloud/client/mutations"
 	queries "github.com/enonic/cli-enonic/internal/app/commands/cloud/client/queries"
+	"github.com/enonic/cli-enonic/internal/app/commands/common"
 	commonUtil "github.com/enonic/cli-enonic/internal/app/util"
 	"github.com/urfave/cli"
 	"os"
@@ -81,7 +82,7 @@ var ProjectDeploy = cli.Command{
 		doDeploy := c.Bool("y")
 
 		// Create deploy context
-		deployCtx, err := createDeployContext(target, jarFile)
+		deployCtx, err := createDeployContext(target, jarFile, common.IsForceMode(c))
 		if err != nil {
 			return err
 		}
@@ -118,10 +119,10 @@ var ProjectDeploy = cli.Command{
 // Functions to setup deployment context
 
 // Create deployment context
-func createDeployContext(target string, deploymentJar string) (*deployContext, error) {
+func createDeployContext(target string, deploymentJar string, force bool) (*deployContext, error) {
 	var jar string
 	// Find jar to deploy
-	jar = commonUtil.PromptProjectJar(deploymentJar)
+	jar = commonUtil.PromptProjectJar(deploymentJar, force)
 
 	// Query api and create service map
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)

--- a/internal/app/commands/cms/reprocess.go
+++ b/internal/app/commands/cms/reprocess.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/enonic/cli-enonic/internal/app/commands/common"
 	"github.com/enonic/cli-enonic/internal/app/util"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"net/http"
 	"os"
@@ -24,7 +25,7 @@ var Reprocess = cli.Command{
 			Name:  "skip-children",
 			Usage: "Flag to skip processing of content children.",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		var result ReprocessResponse
@@ -95,25 +96,30 @@ func createReprocessRequest(c *cli.Context, url string) *http.Request {
 }
 
 func ensurePathFlag(c *cli.Context) {
-	var path = c.String("path")
-
-	path = util.PromptUntilTrue(path, func(val *string, ind byte) string {
-		if len(strings.TrimSpace(*val)) == 0 {
-			switch ind {
-			case 0:
-				return "Enter target content path (<branch-name>:<content-path>): "
-			default:
-				return "Target content path can not be empty. Format: <branch-name>:<content-path>. e.g 'draft:/': "
+	force := common.IsForceMode(c)
+	pathValidator := func(val interface{}) error {
+		str := val.(string)
+		if len(strings.TrimSpace(str)) == 0 {
+			if force {
+				fmt.Fprintln(os.Stderr, "Target content path can not be empty in non-interactive mode.")
+				os.Exit(1)
 			}
+			return errors.New("Target content path can not be empty. Format: <branch-name>:<content-path>. e.g 'draft:/': ")
 		} else {
-			splitPathLen := len(strings.Split(*val, ":"))
+			splitPathLen := len(strings.Split(str, ":"))
 			if splitPathLen != 2 {
-				return fmt.Sprintf("Target content path '%s' must have the following format <branch-name>:<content-path>. e.g 'draft:/': ", *val)
+				if force {
+					fmt.Fprintf(os.Stderr, "Target content path '%s' must have the following format <branch-name>:<content-path>. e.g 'draft:/'\n", str)
+					os.Exit(1)
+				}
+				return errors.Errorf("Target content path '%s' must have the following format <branch-name>:<content-path>. e.g 'draft:/': ", str)
 			} else {
-				return ""
+				return nil
 			}
 		}
-	})
+	}
+
+	path := util.PromptString("Enter target content path (<branch-name>:<content-path>)", c.String("path"), "", pathValidator)
 
 	c.Set("path", path)
 }

--- a/internal/app/commands/common/task.go
+++ b/internal/app/commands/common/task.go
@@ -93,7 +93,7 @@ func doDisplayTaskProgress(taskId, msg string, doneCh chan<- *TaskStatus) {
 }
 
 func fetchTaskStatus(taskId string) (*TaskStatus, bool) {
-	req := doCreateRequest("GET", "/task/"+taskId, "", "", nil)
+	req := doCreateRequest("GET", "/task/"+taskId, "", "", nil, false)
 	resp := SendRequest(req, "")
 	var taskStatus TaskStatus
 	ParseResponse(resp, &taskStatus)

--- a/internal/app/commands/dump/list.go
+++ b/internal/app/commands/dump/list.go
@@ -15,7 +15,7 @@ var List = cli.Command{
 	Name:    "list",
 	Aliases: []string{"ls"},
 	Usage:   "List available dumps",
-	Flags:   append([]cli.Flag{}, common.FLAGS...),
+	Flags:   append([]cli.Flag{}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		dumps := listExistingDumpNames()

--- a/internal/app/commands/dump/load.go
+++ b/internal/app/commands/dump/load.go
@@ -22,10 +22,6 @@ var Load = cli.Command{
 			Usage: "Dump name",
 		},
 		cli.BoolFlag{
-			Name:  "f, force",
-			Usage: "assume “Yes” as answer to all prompts and run non-interactively",
-		},
-		cli.BoolFlag{
 			Name:  "upgrade",
 			Usage: "Upgrade the dump if necessary (default is false)",
 		},
@@ -33,12 +29,13 @@ var Load = cli.Command{
 			Name:  "archive",
 			Usage: "Load dump from archive.",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
-		if c.Bool("f") || util.PromptBool("WARNING: This will delete all existing repositories that also present in the system-dump. Continue ?", false) {
+		force := common.IsForceMode(c)
+		if force || util.PromptBool("WARNING: This will delete all existing repositories that also present in the system-dump. Continue ?", false) {
 
-			name := ensureNameFlag(c.String("d"), false)
+			name := ensureNameFlag(c.String("d"), false, force)
 
 			req := createLoadRequest(c, name)
 			var result LoadDumpResponse

--- a/internal/app/commands/dump/new.go
+++ b/internal/app/commands/dump/new.go
@@ -35,10 +35,10 @@ var Create = cli.Command{
 			Name:  "archive",
 			Usage: "Archive created dump.",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
-		name := ensureNameFlag(c.String("d"), true)
+		name := ensureNameFlag(c.String("d"), true, common.IsForceMode(c))
 
 		req := createNewRequest(c, name)
 

--- a/internal/app/commands/dump/upgrade.go
+++ b/internal/app/commands/dump/upgrade.go
@@ -20,10 +20,10 @@ var Upgrade = cli.Command{
 			Name:  "d",
 			Usage: "Dump name.",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
-		name := ensureNameFlag(c.String("d"), false)
+		name := ensureNameFlag(c.String("d"), false, common.IsForceMode(c))
 
 		req := createUpgradeRequest(c, name)
 		var result UpgradeResult

--- a/internal/app/commands/export/import.go
+++ b/internal/app/commands/export/import.go
@@ -46,7 +46,7 @@ var Import = cli.Command{
 			Name:  "dry",
 			Usage: "Show the result without making actual changes.",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		ensureNameFlag(c)
@@ -72,6 +72,7 @@ var Import = cli.Command{
 
 func ensureXSLParamsFlagFormat(c *cli.Context) {
 	params := c.StringSlice("xsl-param")
+	force := common.IsForceMode(c)
 	xslParams = make(map[string]string)
 
 	for _, param := range params {
@@ -81,6 +82,10 @@ func ensureXSLParamsFlagFormat(c *cli.Context) {
 			if len(strings.TrimSpace(*val)) == 0 || len(splitParam) == 2 {
 				return ""
 			} else {
+				if force {
+					fmt.Fprintf(os.Stderr, "Xsl parameter '%s' must have the following format <parameter-name>=<parameter-value>\n", param)
+					os.Exit(1)
+				}
 				return fmt.Sprintf("Xsl parameter '%s' must have the following format <parameter-name>=<parameter-value>: ", param)
 			}
 		})

--- a/internal/app/commands/project/build.go
+++ b/internal/app/commands/project/build.go
@@ -2,12 +2,14 @@ package project
 
 import (
 	"fmt"
+	"github.com/enonic/cli-enonic/internal/app/commands/common"
 	"github.com/urfave/cli"
 )
 
 var Build = cli.Command{
 	Name:  "build",
 	Usage: "Build current project",
+	Flags: []cli.Flag{common.FORCE_FLAG},
 	Action: func(c *cli.Context) error {
 
 		buildProject(c)
@@ -17,7 +19,7 @@ var Build = cli.Command{
 }
 
 func buildProject(c *cli.Context) {
-	if projectData := ensureProjectDataExists(c, ".", "A sandbox is required for your project, create one?"); projectData != nil {
+	if projectData := ensureProjectDataExists(c, ".", "A sandbox is required for your project, create one?", true); projectData != nil {
 		runGradleTask(projectData, fmt.Sprintf("Building in sandbox '%s'...", projectData.Sandbox), "build")
 	}
 }

--- a/internal/app/commands/project/clean.go
+++ b/internal/app/commands/project/clean.go
@@ -2,15 +2,17 @@ package project
 
 import (
 	"fmt"
+	"github.com/enonic/cli-enonic/internal/app/commands/common"
 	"github.com/urfave/cli"
 )
 
 var Clean = cli.Command{
 	Name:  "clean",
 	Usage: "Clean current project",
+	Flags: []cli.Flag{common.FORCE_FLAG},
 	Action: func(c *cli.Context) error {
 
-		if projectData := ensureProjectDataExists(c, ".", "A sandbox is required to clean the project, do you want to create one?"); projectData != nil {
+		if projectData := ensureProjectDataExists(c, ".", "A sandbox is required to clean the project, do you want to create one?", true); projectData != nil {
 			runGradleTask(projectData, fmt.Sprintf("Cleaning in sandbox '%s'...", projectData.Sandbox), "clean")
 		}
 

--- a/internal/app/commands/project/env.go
+++ b/internal/app/commands/project/env.go
@@ -12,6 +12,7 @@ import (
 var Env = cli.Command{
 	Name:  "env",
 	Usage: "Exports enonic environment variables as string to be used in any third-party shell",
+	Flags: []cli.Flag{common.FORCE_FLAG},
 	Action: func(c *cli.Context) error {
 
 		ensureValidProjectFolder(".")

--- a/internal/app/commands/project/gradle.go
+++ b/internal/app/commands/project/gradle.go
@@ -27,7 +27,7 @@ var Gradle = cli.Command{
 			tasks = append(tasks, arg)
 		}
 
-		if projectData := ensureProjectDataExists(nil, ".", "A sandbox is required to run gradle in the project, do you want to create one?"); projectData != nil {
+		if projectData := ensureProjectDataExists(c, ".", "A sandbox is required to run gradle in the project, do you want to create one?", false); projectData != nil {
 			text := fmt.Sprintf("Running gradle %v in sandbox '%s'...", tasks, projectData.Sandbox)
 			runGradleTask(projectData, text, tasks...)
 		}

--- a/internal/app/commands/project/install.go
+++ b/internal/app/commands/project/install.go
@@ -15,7 +15,7 @@ var Install = cli.Command{
 	Name:    "install",
 	Aliases: []string{"i"},
 	Usage:   "Build current project and install it to Enonic XP",
-	Flags:   append([]cli.Flag{}, common.FLAGS...),
+	Flags:   append([]cli.Flag{}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		buildProject(c)

--- a/internal/app/commands/project/sandbox.go
+++ b/internal/app/commands/project/sandbox.go
@@ -12,12 +12,13 @@ var Sandbox = cli.Command{
 	Name:    "sandbox",
 	Aliases: []string{"sbox", "sb"},
 	Usage:   "Set the default sandbox associated with the current project",
+	Flags:   []cli.Flag{common.FORCE_FLAG},
 	Action: func(c *cli.Context) error {
 
 		ensureValidProjectFolder(".")
 
 		minDistroVersion := common.ReadProjectDistroVersion(".")
-		sandbox, _ := sandbox.EnsureSandboxExists(c, minDistroVersion, "No sandboxes found, do you want to create one?", "Select sandbox to use as default for this project:", true, true)
+		sandbox, _ := sandbox.EnsureSandboxExists(c, minDistroVersion, "No sandboxes found, do you want to create one?", "Select sandbox to use as default for this project:", true, true, true)
 		if sandbox == nil {
 			os.Exit(1)
 		}

--- a/internal/app/commands/repo/list.go
+++ b/internal/app/commands/repo/list.go
@@ -12,7 +12,7 @@ var List = cli.Command{
 	Name:    "list",
 	Aliases: []string{"ls"},
 	Usage:   "List available repos",
-	Flags:   append([]cli.Flag{}, common.FLAGS...),
+	Flags:   append([]cli.Flag{}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		req := common.CreateRequest(c, "GET", "repo/list", nil)

--- a/internal/app/commands/repo/read-only.go
+++ b/internal/app/commands/repo/read-only.go
@@ -20,7 +20,7 @@ var ReadOnly = cli.Command{
 			Name:  "r",
 			Usage: "Single repository to toggle read-only mode for",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		readOnly := ensureReadOnlyArg(c)

--- a/internal/app/commands/repo/reindex.go
+++ b/internal/app/commands/repo/reindex.go
@@ -29,7 +29,7 @@ var Reindex = cli.Command{
 			Name:  "i",
 			Usage: "If true, the indices will be deleted before recreated.",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		var result ReindexResponse

--- a/internal/app/commands/repo/replicas.go
+++ b/internal/app/commands/repo/replicas.go
@@ -16,7 +16,7 @@ import (
 var Replicas = cli.Command{
 	Name:  "replicas",
 	Usage: "Set the number of replicas in the cluster.",
-	Flags: append([]cli.Flag{}, common.FLAGS...),
+	Flags: append([]cli.Flag{}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		replicasNum := ensureReplicasNumberArg(c)

--- a/internal/app/commands/sandbox/create.go
+++ b/internal/app/commands/sandbox/create.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"fmt"
+	"github.com/enonic/cli-enonic/internal/app/commands/common"
 	"github.com/enonic/cli-enonic/internal/app/util"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -23,6 +24,7 @@ var Create = cli.Command{
 			Name:  "all, a",
 			Usage: "List all distro versions.",
 		},
+		common.FORCE_FLAG,
 	},
 	Action: func(c *cli.Context) error {
 
@@ -31,16 +33,16 @@ var Create = cli.Command{
 			name = c.Args().First()
 		}
 
-		SandboxCreateWizard(name, c.String("version"), "", c.Bool("all"), true)
+		SandboxCreateWizard(name, c.String("version"), "", c.Bool("all"), true, common.IsForceMode(c))
 
 		return nil
 	},
 }
 
-func SandboxCreateWizard(name, versionStr, minDistroVersion string, includeUnstable, showSuccessMessage bool) *Sandbox {
+func SandboxCreateWizard(name, versionStr, minDistroVersion string, includeUnstable, showSuccessMessage, force bool) *Sandbox {
 
-	name = ensureUniqueNameArg(name, minDistroVersion)
-	version := ensureVersionCorrect(versionStr, minDistroVersion, includeUnstable)
+	name = ensureUniqueNameArg(name, minDistroVersion, force)
+	version := ensureVersionCorrect(versionStr, minDistroVersion, includeUnstable, force)
 
 	box := createSandbox(name, version)
 
@@ -54,17 +56,25 @@ func SandboxCreateWizard(name, versionStr, minDistroVersion string, includeUnsta
 	return box
 }
 
-func ensureUniqueNameArg(name, minDistroVersion string) string {
+func ensureUniqueNameArg(name, minDistroVersion string, force bool) string {
 	existingBoxes := listSandboxes(minDistroVersion)
 	defaultSandboxName := getFirstValidSandboxName(existingBoxes)
 
 	var sandboxValidator = func(val interface{}) error {
 		str := val.(string)
 		if len(strings.TrimSpace(str)) < 3 {
-			return errors.New("Sandbox name must be at least 3 characters long")
+			if force {
+				// Assume defaultSandboxName in force mode
+				return nil
+			}
+			return errors.New("Sandbox name must be at least 3 characters long: ")
 		} else {
 			for _, existingBox := range existingBoxes {
 				if existingBox.Name == str {
+					if force {
+						fmt.Fprintf(os.Stderr, "Sandbox with name '%s' already exists\n", str)
+						os.Exit(1)
+					}
 					return errors.Errorf("Sandbox with name '%s' already exists: ", str)
 				}
 			}
@@ -72,7 +82,12 @@ func ensureUniqueNameArg(name, minDistroVersion string) string {
 		}
 	}
 
-	return util.PromptString("Sandbox name", name, defaultSandboxName, sandboxValidator)
+	userSandboxName := util.PromptString("Sandbox name", name, defaultSandboxName, sandboxValidator)
+	if !force || userSandboxName != "" {
+		return userSandboxName
+	} else {
+		return defaultSandboxName
+	}
 }
 
 func getFirstValidSandboxName(sandboxes []*Sandbox) string {

--- a/internal/app/commands/sandbox/delete.go
+++ b/internal/app/commands/sandbox/delete.go
@@ -12,24 +12,20 @@ var Delete = cli.Command{
 	Name:    "delete",
 	Usage:   "Delete a sandbox",
 	Aliases: []string{"del", "rm"},
-	Flags: []cli.Flag{
-		cli.BoolFlag{
-			Name:  "f, force",
-			Usage: "assume “Yes” as answer to all prompts and run non-interactively",
-		},
-	},
+	Flags:   []cli.Flag{common.FORCE_FLAG},
 	Action: func(c *cli.Context) error {
-		sandbox, _ := EnsureSandboxExists(c, "", "No sandboxes found, do you want to create one?", "Select sandbox to delete:", true, false)
-		if sandbox == nil || !(c.Bool("f") || acceptToDeleteSandbox(sandbox.Name)) {
+		sandbox, _ := EnsureSandboxExists(c, "", "No sandboxes found, do you want to create one?", "Select sandbox to delete:", true, false, true)
+		force := common.IsForceMode(c)
+		if sandbox == nil || !acceptToDeleteSandbox(sandbox.Name, force) {
 			os.Exit(1)
 		}
 
 		if rData := common.ReadRuntimeData(); rData.Running == sandbox.Name {
-			AskToStopSandbox(rData)
+			AskToStopSandbox(rData, force)
 		}
 
 		boxes := getSandboxesUsingDistro(sandbox.Distro)
-		if len(boxes) == 1 && boxes[0].Name == sandbox.Name && acceptToDeleteDistro(sandbox.Distro) {
+		if len(boxes) == 1 && boxes[0].Name == sandbox.Name && acceptToDeleteDistro(sandbox.Distro, force) {
 			deleteDistro(sandbox.Distro)
 		}
 
@@ -40,10 +36,10 @@ var Delete = cli.Command{
 	},
 }
 
-func acceptToDeleteSandbox(name string) bool {
-	return util.PromptBool(fmt.Sprintf("WARNING: This can not be undone ! Do you still want to delete sandbox '%s' ?", name), false)
+func acceptToDeleteSandbox(name string, force bool) bool {
+	return force || util.PromptBool(fmt.Sprintf("WARNING: This can not be undone ! Do you still want to delete sandbox '%s' ?", name), false)
 }
 
-func acceptToDeleteDistro(name string) bool {
-	return util.PromptBool(fmt.Sprintf("Distro '%s' is not used any more. Do you want to delete it ?", name), true)
+func acceptToDeleteDistro(name string, force bool) bool {
+	return force || util.PromptBool(fmt.Sprintf("Distro '%s' is not used any more. Do you want to delete it ?", name), true)
 }

--- a/internal/app/commands/sandbox/distro.go
+++ b/internal/app/commands/sandbox/distro.go
@@ -318,7 +318,7 @@ func EnsureSanboxSupportsProjectVersion(sBox *Sandbox, minDistroVersion *semver.
 	}
 }
 
-func ensureVersionCorrect(versionStr, minDistroVer string, includeUnstable bool) string {
+func ensureVersionCorrect(versionStr, minDistroVer string, includeUnstable, force bool) string {
 	var (
 		version       *semver.Version
 		versionErr    error
@@ -328,6 +328,9 @@ func ensureVersionCorrect(versionStr, minDistroVer string, includeUnstable bool)
 	if len(strings.TrimSpace(versionStr)) > 0 {
 		if version, versionErr = semver.NewVersion(versionStr); versionErr != nil {
 			fmt.Fprintf(os.Stderr, "'%s' is not a valid distro version.\n", versionStr)
+			if force {
+				os.Exit(1)
+			}
 		}
 	}
 
@@ -344,6 +347,14 @@ func ensureVersionCorrect(versionStr, minDistroVer string, includeUnstable bool)
 	if version != nil && versionExists {
 		return version.String()
 	} else {
+		if force {
+			if version == nil {
+				fmt.Fprintln(os.Stderr, "Version flag can not be empty in non-interactive mode.")
+			} else {
+				fmt.Fprintf(os.Stderr, "Version '%s' can not be found.\n", versionStr)
+			}
+			os.Exit(1)
+		}
 
 		defaultVersion := findLatestVersion(versions)
 		var distro string

--- a/internal/app/commands/sandbox/list.go
+++ b/internal/app/commands/sandbox/list.go
@@ -11,6 +11,7 @@ import (
 var List = cli.Command{
 	Name:    "list",
 	Aliases: []string{"ls"},
+	Flags:   []cli.Flag{common.FORCE_FLAG},
 	Usage:   "List all sandboxes",
 	Action: func(c *cli.Context) error {
 		rData := common.ReadRuntimeData()

--- a/internal/app/commands/sandbox/stop.go
+++ b/internal/app/commands/sandbox/stop.go
@@ -10,6 +10,7 @@ import (
 var Stop = cli.Command{
 	Name:  "stop",
 	Usage: "Stop the sandbox started in detached mode.",
+	Flags: []cli.Flag{common.FORCE_FLAG},
 	Action: func(c *cli.Context) error {
 
 		rData := common.ReadRuntimeData()

--- a/internal/app/commands/sandbox/upgrade.go
+++ b/internal/app/commands/sandbox/upgrade.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"fmt"
 	"github.com/Masterminds/semver"
+	"github.com/enonic/cli-enonic/internal/app/commands/common"
 	"github.com/enonic/cli-enonic/internal/app/util"
 	"github.com/urfave/cli"
 	"os"
@@ -21,14 +22,15 @@ var Upgrade = cli.Command{
 			Name:  "all, a",
 			Usage: "List all distro versions.",
 		},
+		common.FORCE_FLAG,
 	},
 	Action: func(c *cli.Context) error {
 
-		sandbox, _ := EnsureSandboxExists(c, "", "No sandboxes found, do you want to create one?", "Select sandbox:", true, false)
+		sandbox, _ := EnsureSandboxExists(c, "", "No sandboxes found, do you want to create one?", "Select sandbox:", true, false, true)
 		if sandbox == nil {
 			os.Exit(1)
 		}
-		version := ensureVersionCorrect(c.String("version"), "", c.Bool("all"))
+		version := ensureVersionCorrect(c.String("version"), "", c.Bool("all"), common.IsForceMode(c))
 		preventVersionDowngrade(sandbox, version)
 
 		sandbox.Distro = formatDistroVersion(version, util.GetCurrentOs())

--- a/internal/app/commands/snapshot/delete.go
+++ b/internal/app/commands/snapshot/delete.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/enonic/cli-enonic/internal/app/commands/common"
 	"github.com/enonic/cli-enonic/internal/app/util"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"net/http"
 	"os"
@@ -28,7 +29,7 @@ var Delete = cli.Command{
 			Name:  "snapshot, snap",
 			Usage: "The name of the snapshot to delete",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		ensureSnapshotOrBeforeFlag(c)
@@ -49,18 +50,22 @@ var Delete = cli.Command{
 func ensureSnapshotOrBeforeFlag(c *cli.Context) {
 	snapshot := c.String("snapshot")
 	before := c.String("before")
+	force := common.IsForceMode(c)
 
 	if snapshot == "" && before == "" {
+		if force {
+			fmt.Fprintf(os.Stderr, "Either before or snapshot flag should not be empty in non-interactive mode.")
+			os.Exit(1)
+		}
 		var val string
-		val = util.PromptUntilTrue(val, func(val *string, ind byte) string {
-			if *val == "" && ind == 0 {
-				return "Select by [N]ame or by [D]ate? "
-			} else if upper := strings.ToUpper(*val); upper != "N" && upper != "D" {
-				return `Please type "N" for Name or "D" for Date: `
-			} else {
-				return ""
+		choiceValidator := func(val interface{}) error {
+			str := val.(string)
+			if upper := strings.ToUpper(str); upper != "N" && upper != "D" {
+				return errors.Errorf("'%s' is not a valid choice. Please use 'N' for Name or 'D' for Date: ", str)
 			}
-		})
+			return nil
+		}
+		util.PromptString("Select by [N]ame or by [D]ate:", val, "N", choiceValidator)
 		switch val {
 		case "N", "n":
 			ensureSnapshotFlag(c)
@@ -70,23 +75,29 @@ func ensureSnapshotOrBeforeFlag(c *cli.Context) {
 	}
 }
 func ensureBeforeFlag(c *cli.Context) {
-
-	before := util.PromptUntilTrue(c.String("before"), func(val *string, ind byte) string {
-		if len(strings.TrimSpace(*val)) == 0 {
-			switch ind {
-			case 0:
-				return fmt.Sprintf("Enter date in the format %s: ", time.Now().Format(DATE_FORMAT))
-			default:
-				return fmt.Sprintf("Before date can not be empty. Format %s: ", time.Now().Format(DATE_FORMAT))
+	force := common.IsForceMode(c)
+	label := fmt.Sprintf("Enter date in the format %s: ", time.Now().Format(DATE_FORMAT))
+	dateValidator := func(val interface{}) error {
+		str := val.(string)
+		if len(strings.TrimSpace(str)) == 0 {
+			if force {
+				fmt.Fprintln(os.Stderr, "Before flag can not be empty in non-interactive mode.")
+				os.Exit(1)
 			}
+			return fmt.Errorf("Before date can not be empty. Format %s: ", time.Now().Format(DATE_FORMAT))
 		} else {
-			if _, err := time.Parse(DATE_FORMAT, *val); err != nil {
-				return "Not a valid date: "
+			if _, err := time.Parse(DATE_FORMAT, str); err != nil {
+				if force {
+					fmt.Fprintf(os.Stderr, "Not a valid date: %s", str)
+					os.Exit(1)
+				}
+				return errors.New("Not a valid date: ")
 			} else {
-				return ""
+				return nil
 			}
 		}
-	})
+	}
+	before := util.PromptString(label, c.String("before"), label, dateValidator)
 
 	c.Set("before", before)
 }

--- a/internal/app/commands/snapshot/list.go
+++ b/internal/app/commands/snapshot/list.go
@@ -12,7 +12,7 @@ var List = cli.Command{
 	Name:    "list",
 	Aliases: []string{"ls"},
 	Usage:   "Returns a list of existing snapshots with name and status.",
-	Flags:   common.FLAGS,
+	Flags:   []cli.Flag{common.AUTH_FLAG, common.FORCE_FLAG},
 	Action: func(c *cli.Context) error {
 
 		snapshots := listSnapshots(c)

--- a/internal/app/commands/snapshot/new.go
+++ b/internal/app/commands/snapshot/new.go
@@ -19,7 +19,7 @@ var Create = cli.Command{
 			Name:  "repo, r",
 			Usage: "The name of the repository to snapshot",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		req := createNewRequest(c)

--- a/internal/app/commands/snapshot/restore.go
+++ b/internal/app/commands/snapshot/restore.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli"
 	"net/http"
 	"os"
+	"strings"
 )
 
 var Restore = cli.Command{
@@ -28,7 +29,7 @@ var Restore = cli.Command{
 			Name:  "latest",
 			Usage: "Flag to use latest snapshot, takes precedence over name flag",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 
 		req := createRestoreRequest(c)
@@ -50,7 +51,11 @@ var Restore = cli.Command{
 
 func ensureSnapshotFlag(c *cli.Context) string {
 	snapName := c.String("snapshot")
-	if snapName == "" {
+	if len(strings.TrimSpace(snapName)) == 0 {
+		if common.IsForceMode(c) {
+			fmt.Fprintln(os.Stderr, "Snapshot name can not be empty in non-interactive mode.")
+			os.Exit(1)
+		}
 
 		snapshotList := listSnapshots(c)
 		if len(snapshotList.Results) == 0 {

--- a/internal/app/commands/system/info.go
+++ b/internal/app/commands/system/info.go
@@ -12,7 +12,7 @@ var Info = cli.Command{
 	Name:    "info",
 	Aliases: []string{"i"},
 	Usage:   "XP distribution info",
-	Flags:   common.FLAGS,
+	Flags:   []cli.Flag{common.AUTH_FLAG, common.FORCE_FLAG},
 	Action: func(c *cli.Context) error {
 
 		req := common.CreateRequest(c, "GET", "http://localhost:2609/server", nil)

--- a/internal/app/commands/system/latest.go
+++ b/internal/app/commands/system/latest.go
@@ -12,7 +12,7 @@ import (
 var Latest = cli.Command{
 	Name:  "latest",
 	Usage: "Check for latest version",
-	Flags: common.FLAGS,
+	Flags: []cli.Flag{common.AUTH_FLAG, common.FORCE_FLAG},
 	Action: func(c *cli.Context) error {
 		fmt.Fprintln(os.Stderr, "")
 		req := common.CreateRequest(c, "GET", common.SCOOP_MANIFEST_URL, nil)

--- a/internal/app/commands/vacuum/vacuum.go
+++ b/internal/app/commands/vacuum/vacuum.go
@@ -19,7 +19,7 @@ var Vacuum = cli.Command{
 			Name:  "blob, b",
 			Usage: "Also removes unused blobs from the blobstore",
 		},
-	}, common.FLAGS...),
+	}, common.AUTH_FLAG, common.FORCE_FLAG),
 	Action: func(c *cli.Context) error {
 		req := createVacuumRequest(c)
 

--- a/internal/app/util/util.go
+++ b/internal/app/util/util.go
@@ -92,11 +92,16 @@ func filterJars(libs []os.FileInfo) []string {
 	return jars
 }
 
-func PromptProjectJar(inputJar string) string {
+func PromptProjectJar(inputJar string, force bool) string {
 	var projectJar string
 	var fileValidator = func(val interface{}) error {
 		str := val.(string)
 		if len(strings.TrimSpace(str)) == 0 {
+			if force {
+				fmt.Fprintf(os.Stderr, "Snapshot name can not be empty in non-interactive mode.")
+				os.Exit(1)
+			}
+
 			libs, err := ioutil.ReadDir(filepath.Join("build", "libs"))
 			if err != nil {
 				return errors.New("Could not read project build folder")
@@ -125,6 +130,10 @@ func PromptProjectJar(inputJar string) string {
 			}
 		} else {
 			if _, err := os.Stat(str); err != nil {
+				if force {
+					fmt.Fprintf(os.Stderr, "File '%s' does not exist", str)
+					os.Exit(1)
+				}
 				return fmt.Errorf("File '%s' does not exist", str)
 			}
 			projectJar = str
@@ -137,6 +146,7 @@ func PromptProjectJar(inputJar string) string {
 	return projectJar
 }
 
+// Deprecated: use PropmtString, PromptPassword, PromptBool instead
 func PromptUntilTrue(val string, assessFunc func(val *string, i byte) string) string {
 	index := byte(0)
 	text := assessFunc(&val, index)


### PR DESCRIPTION
There are too many code changes so it will be probably easier to test the binaries:
Linux
[enonic_1.5.1-next_Linux_64-bit.tar.gz](https://github.com/enonic/cli-enonic/files/6310820/enonic_1.5.1-next_Linux_64-bit.tar.gz)
Mac
[enonic_1.5.1-next_Mac_64-bit.tar.gz](https://github.com/enonic/cli-enonic/files/6310822/enonic_1.5.1-next_Mac_64-bit.tar.gz)
Windows
[enonic_1.5.1-next_Windows_64-bit.zip](https://github.com/enonic/cli-enonic/files/6310826/enonic_1.5.1-next_Windows_64-bit.zip)
