### PR TITLE
Make arm uppercase in release files #332

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,6 +74,8 @@ archives:
       windows: Windows
       amd64: 64-bit
       386: 32-bit
+      arm: Arm
+      arm64: Arm64
 
     format: tar.gz  # set to binary to omit archiving
 
@@ -205,6 +207,8 @@ nfpms:
       windows: Windows
       amd64: 64-bit
       386: 32-bit
+      arm: Arm
+      arm64: Arm64
 
     # Your app's vendor.
     # Default is empty.
@@ -246,6 +250,8 @@ snapcrafts:
       windows: Windows
       amd64: 64-bit
       386: 32-bit
+      arm: Arm
+      arm64: Arm64
 
     # The name of the snap. This is optional.
     # Default is project name.


### PR DESCRIPTION
Now the build artifacts will be named like this:

- enonic_2.0.2_Linux_64-bit.deb
- enonic_2.0.2_Linux_64-bit.tar.gz
- enonic_2.0.2_Linux_Arm64.deb
- enonic_2.0.2_Linux_Arm64.tar.gz
- enonic_2.0.2_Linux_Armv6.deb
- enonic_2.0.2_Linux_Armv6.tar.gz
- enonic_2.0.2_Linux_Armv7.deb
- enonic_2.0.2_Linux_Armv7.tar.gz
- enonic_2.0.2_Mac_64-bit.tar.gz
- enonic_2.0.2_Mac_Arm64.tar.gz
- enonic_2.0.2_Windows_64-bit.zip
- enonic_2.0.2_Windows_Armv6.zip
- enonic_2.0.2_Windows_Armv7.zip