### PR TITLE
Reduce duplicated code and expose a function for getting the enonic home dir

### DIFF
--- a/internal/app/commands/remote/remote.go
+++ b/internal/app/commands/remote/remote.go
@@ -77,7 +77,7 @@ type RemotesData struct {
 }
 
 func readRemotesData() RemotesData {
-	path := filepath.Join(util.GetHomeDir(), ".enonic", ".enonic")
+	path := filepath.Join(util.GetEnonicHome(), ".enonic")
 	file := util.OpenOrCreateDataFile(path, true)
 	defer file.Close()
 
@@ -90,7 +90,7 @@ func readRemotesData() RemotesData {
 }
 
 func writeRemotesData(data RemotesData) {
-	path := filepath.Join(util.GetHomeDir(), ".enonic", ".enonic")
+	path := filepath.Join(util.GetEnonicHome(), ".enonic")
 	file := util.OpenOrCreateDataFile(path, false)
 	defer file.Close()
 

--- a/internal/app/commands/sandbox/sandbox.go
+++ b/internal/app/commands/sandbox/sandbox.go
@@ -318,11 +318,7 @@ func updateXPConfig(sandboxName string) {
 }
 
 func ensureDirStructure() {
-	// Using go-homedir instead of user.Current()
-	// because of https://github.com/golang/go/issues/6376
-	home := util.GetHomeDir()
-
-	enonicPath := filepath.Join(home, ".enonic")
+	enonicPath := util.GetEnonicHome()
 	enonicPathInfo, _ := os.Lstat(enonicPath)
 	enonicPathExists := enonicPathInfo != nil
 	enonicPathIsSymlink := enonicPathExists && enonicPathInfo.Mode()&os.ModeSymlink == os.ModeSymlink
@@ -374,8 +370,8 @@ func ensureDirStructure() {
 		}
 	}
 
-	createFolderIfNotExist(home, ".enonic", "distributions")
-	createFolderIfNotExist(home, ".enonic", "sandboxes")
+	createFolderIfNotExist(enonicPath, "distributions")
+	createFolderIfNotExist(enonicPath, "sandboxes")
 }
 
 func mustMove(from, to string) {

--- a/internal/app/util/util.go
+++ b/internal/app/util/util.go
@@ -257,6 +257,13 @@ func GetCurrentOsWithArch() string {
 	return currentOs
 }
 
+func GetEnonicHome() string {
+	// Using go-homedir instead of user.Current()
+	// because of https://github.com/golang/go/issues/6376
+	home := GetHomeDir()
+	return filepath.Join(home, ".enonic")
+}
+
 // Taken from go-homedir
 func GetHomeDir() string {
 	var result string

--- a/internal/app/util/util_test.go
+++ b/internal/app/util/util_test.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+    "testing"
+	"os"
+	"path/filepath"
+)
+
+func TestGetHomeDir(t *testing.T) {
+	expected := os.Getenv("HOME")
+	home := GetHomeDir()
+	if home != expected {
+		t.Errorf("GetHomeDir() failed: %s", home)
+	}
+}
+
+func TestGetEnonicDir(t *testing.T) {
+	expected := filepath.Join(os.Getenv("HOME"), ".enonic")
+	home := GetEnonicHome()
+	if home != expected {
+		t.Errorf("GetHomeDir() failed: %s", home)
+	}
+}


### PR DESCRIPTION
This relates to #570 

So if I wanted to make sure the directory was possible to override, I would first consolidate all different places the path to $HOME/.enonic was found.

Here is a first attempt to do that. Plus some actual tests for this repo