### PR TITLE
Add app list command with Server-Sent Events stream parsing

### DIFF
--- a/docs/xp.adoc
+++ b/docs/xp.adoc
@@ -486,7 +486,7 @@ include::.snippets.adoc[tag=credentials-flags]
 
 include::.snippets.adoc[tag=credentials-flags-notes]
 
-NOTE: This command requires XP 8.0 or later.
+NOTE: This command requires XP 7.6 or later.
 
 .Example listing installed apps:
 ----

--- a/docs/xp.adoc
+++ b/docs/xp.adoc
@@ -468,15 +468,18 @@ $ enonic app install --cred-file path\to\cred-file.json --file /Users/nerd/Dev/a
 
 === List
 
-List the applications installed on the instance, with their state and version.
+List the applications installed on the instance, sorted by application key.
 
- $ enonic app list [-a <value>] [--cred-file <value>] [-f]
+ $ enonic app list [--json] [-a <value>] [--cred-file <value>] [-f]
 
 Options:
 [cols="1,3", options="header"]
 |===
 |Option
 |Description
+
+|`--json`
+|print the full details of every application as JSON instead of a table
 
 include::.snippets.adoc[tag=credentials-flags]
 
@@ -491,10 +494,20 @@ NOTE: This command requires XP 7.6 or later.
 .Example listing installed apps:
 ----
 $ enonic app list --cred-file path\to\cred-file.json
+
+KEY                            NAME             VERSION          STATE     LOCAL
+com.enonic.app.contentstudio   Content Studio   5.4.1            started
+com.enonic.app.mytestapp                        1.0.0-SNAPSHOT   stopped   yes
+com.enonic.app.superhero       Superhero        2.0.5            started
 ----
 
-.Example output:
+TIP: The table is written to standard output and the progress messages to standard error, so `enonic app list 2>/dev/null` gives you a clean list to pipe into other tools.
+
+The `--json` flag prints every field XP reports, which is useful for scripting:
+
 ----
+$ enonic app list --json --cred-file path\to\cred-file.json
+
 {
     "applications": [
         {

--- a/docs/xp.adoc
+++ b/docs/xp.adoc
@@ -411,18 +411,21 @@ This option could for example be used for renaming types or fields. The .xsl fil
 
 == App
 
-Commands to install applications to the running enonic XP instance. Currently only one command is available here:
+Commands to manage applications on the running Enonic XP instance:
 
 ----
 $ enonic app
 
-Install, stop and start applications
+Install, list, stop and start applications
 
 USAGE:
    Enonic CLI app command [command options] [arguments...]
 
 COMMANDS:
      install, i  Install an application from URL or file
+     list, ls    List installed applications
+     start       Start an application
+     stop        Stop an application
 
 OPTIONS:
    --help, -h  show help
@@ -461,6 +464,54 @@ $ enonic app install --cred-file path\to\cred-file.json --url https://repo.enoni
 .Example installing app from a file:
 ----
 $ enonic app install --cred-file path\to\cred-file.json --file /Users/nerd/Dev/apps/coolapp/build/libs/coolapp-1.0.0-SNAPSHOT.jar
+----
+
+=== List
+
+List the applications installed on the instance, with their state and version.
+
+ $ enonic app list [-a <value>] [--cred-file <value>] [-f]
+
+Options:
+[cols="1,3", options="header"]
+|===
+|Option
+|Description
+
+include::.snippets.adoc[tag=credentials-flags]
+
+|`-f, --force`
+|accept default answers to all prompts and run non-interactively
+|===
+
+include::.snippets.adoc[tag=credentials-flags-notes]
+
+NOTE: This command requires XP 8.0 or later.
+
+.Example listing installed apps:
+----
+$ enonic app list --cred-file path\to\cred-file.json
+----
+
+.Example output:
+----
+{
+    "applications": [
+        {
+            "key": "com.enonic.app.superhero",
+            "displayName": "Superhero",
+            "version": "2.0.5",
+            "state": "started",
+            "local": false,
+            "modifiedTime": "2026-08-17T10:00:00Z",
+            "minSystemVersion": "7.7.0",
+            "maxSystemVersion": "8",
+            "url": "https://market.enonic.com/",
+            "vendorName": "Enonic AS",
+            "vendorUrl": "https://enonic.com"
+        }
+    ]
+}
 ----
 
 === Start

--- a/internal/app/commands/app/app.go
+++ b/internal/app/commands/app/app.go
@@ -13,6 +13,7 @@ import (
 func All() []cli.Command {
 	return []cli.Command{
 		Install,
+		List,
 		Start,
 		Stop,
 	}

--- a/internal/app/commands/app/list.go
+++ b/internal/app/commands/app/list.go
@@ -10,6 +10,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
 	"time"
 )
 
@@ -20,15 +23,49 @@ var List = cli.Command{
 	Name:    "list",
 	Aliases: []string{"ls"},
 	Usage:   "List installed applications",
-	Flags:   append([]cli.Flag{common.FORCE_FLAG}, common.AUTH_AND_TLS_FLAGS...),
+	Flags: append([]cli.Flag{
+		cli.BoolFlag{
+			Name:  "json",
+			Usage: "Print the full application details as JSON",
+		},
+		common.FORCE_FLAG,
+	}, common.AUTH_AND_TLS_FLAGS...),
 	Action: func(c *cli.Context) error {
 
 		apps := listApps(c)
 
-		fmt.Fprintln(os.Stdout, util.PrettyPrintJSON(apps))
+		sort.Slice(apps.Applications, func(i, j int) bool {
+			return apps.Applications[i].Key < apps.Applications[j].Key
+		})
+
+		if c.Bool("json") {
+			fmt.Fprintln(os.Stdout, util.PrettyPrintJSON(apps))
+		} else {
+			printApplications(os.Stdout, apps.Applications)
+		}
 
 		return nil
 	},
+}
+
+// printApplications writes the applications as an aligned table, leaving the
+// details that only scripts care about to the --json flag.
+func printApplications(out io.Writer, apps []Application) {
+	if len(apps) == 0 {
+		fmt.Fprintln(os.Stderr, "No applications installed")
+		return
+	}
+
+	writer := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(writer, strings.Join([]string{"KEY", "NAME", "VERSION", "STATE", "LOCAL"}, "\t"))
+	for _, app := range apps {
+		local := ""
+		if app.Local {
+			local = "yes"
+		}
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", app.Key, app.DisplayName, app.Version, app.State, local)
+	}
+	writer.Flush()
 }
 
 func listApps(c *cli.Context) *ApplicationsResult {

--- a/internal/app/commands/app/list.go
+++ b/internal/app/commands/app/list.go
@@ -16,7 +16,6 @@ import (
 	"time"
 )
 
-// XP publishes the installed applications as the first event on the app events stream
 const LIST_EVENT = "list"
 
 var List = cli.Command{
@@ -48,8 +47,6 @@ var List = cli.Command{
 	},
 }
 
-// printApplications writes the applications as an aligned table, leaving the
-// details that only scripts care about to the --json flag.
 func printApplications(out io.Writer, apps []Application) {
 	if len(apps) == 0 {
 		fmt.Fprintln(os.Stderr, "No applications installed")
@@ -69,6 +66,7 @@ func printApplications(out io.Writer, apps []Application) {
 }
 
 func listApps(c *cli.Context) *ApplicationsResult {
+	// XP has no endpoint that returns the applications, they only arrive as the first event on this stream
 	req := common.CreateRequest(c, "GET", "app/events", nil)
 	req.Header.Set("Accept", common.SSE_CONTENT_TYPE)
 
@@ -76,11 +74,9 @@ func listApps(c *cli.Context) *ApplicationsResult {
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		// not an event stream, so report it the way the other commands do.
-		// ParseResponse exits on a failure response, anything else is unusable here
 		var body interface{}
 		common.ParseResponse(res, &body)
-		os.Exit(1)
+		os.Exit(1) // ParseResponse already exits on a failure response, a 2xx without a stream is unusable too
 	}
 
 	result, err := readApplicationList(res.Body)
@@ -94,8 +90,6 @@ func listApps(c *cli.Context) *ApplicationsResult {
 	return result
 }
 
-// readApplicationList returns the applications carried by the first "list" event
-// on an app events stream, ignoring any other event that may arrive before it.
 func readApplicationList(stream io.Reader) (*ApplicationsResult, error) {
 	reader := common.NewSseReader(stream)
 

--- a/internal/app/commands/app/list.go
+++ b/internal/app/commands/app/list.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"cli-enonic/internal/app/commands/common"
+	"cli-enonic/internal/app/util"
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+// XP publishes the installed applications as the first event on the app events stream
+const LIST_EVENT = "list"
+
+var List = cli.Command{
+	Name:    "list",
+	Aliases: []string{"ls"},
+	Usage:   "List installed applications",
+	Flags:   append([]cli.Flag{common.FORCE_FLAG}, common.AUTH_AND_TLS_FLAGS...),
+	Action: func(c *cli.Context) error {
+
+		apps := listApps(c)
+
+		fmt.Fprintln(os.Stdout, util.PrettyPrintJSON(apps))
+
+		return nil
+	},
+}
+
+func listApps(c *cli.Context) *ApplicationsResult {
+	req := common.CreateRequest(c, "GET", "app/events", nil)
+	req.Header.Set("Accept", common.SSE_CONTENT_TYPE)
+
+	res := common.SendRequest(c, req, "Loading applications")
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		// not an event stream, so report it the way the other commands do.
+		// ParseResponse exits on a failure response, anything else is unusable here
+		var body interface{}
+		common.ParseResponse(res, &body)
+		os.Exit(1)
+	}
+
+	result, err := readApplicationList(res.Body)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error reading applications: ", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintln(os.Stderr, "Done")
+
+	return result
+}
+
+// readApplicationList returns the applications carried by the first "list" event
+// on an app events stream, ignoring any other event that may arrive before it.
+func readApplicationList(stream io.Reader) (*ApplicationsResult, error) {
+	reader := common.NewSseReader(stream)
+
+	for {
+		event, err := reader.Next()
+		if err != nil {
+			if err == io.EOF {
+				return nil, errors.Errorf("stream ended without a '%s' event", LIST_EVENT)
+			}
+			return nil, err
+		}
+
+		if event.Event != LIST_EVENT {
+			continue
+		}
+
+		var result ApplicationsResult
+		if err = json.Unmarshal([]byte(event.Data), &result); err != nil {
+			return nil, err
+		}
+		return &result, nil
+	}
+}
+
+type ApplicationsResult struct {
+	Applications []Application `json:"applications"`
+}
+
+type Application struct {
+	Key              string    `json:"key"`
+	DisplayName      string    `json:"displayName,omitempty"`
+	Version          string    `json:"version"`
+	State            string    `json:"state"`
+	Local            bool      `json:"local"`
+	ModifiedTime     time.Time `json:"modifiedTime"`
+	MinSystemVersion string    `json:"minSystemVersion,omitempty"`
+	MaxSystemVersion string    `json:"maxSystemVersion,omitempty"`
+	Url              string    `json:"url,omitempty"`
+	VendorName       string    `json:"vendorName,omitempty"`
+	VendorUrl        string    `json:"vendorUrl,omitempty"`
+}

--- a/internal/app/commands/app/list_test.go
+++ b/internal/app/commands/app/list_test.go
@@ -47,7 +47,6 @@ func TestReadApplicationList(t *testing.T) {
 		t.Error("expected modified time to be parsed")
 	}
 
-	// XP omits fields that have no value, they must not break parsing
 	local := result.Applications[1]
 	if !local.Local || local.State != "stopped" || local.DisplayName != "" {
 		t.Errorf("unexpected local application: %+v", local)

--- a/internal/app/commands/app/list_test.go
+++ b/internal/app/commands/app/list_test.go
@@ -110,3 +110,30 @@ data: {"applications":[{"key":"com.enonic.app.local","version":"1.0.0","state":"
 		t.Errorf("unexpected application: %+v", app)
 	}
 }
+
+func TestPrintApplications(t *testing.T) {
+	result, err := readApplicationList(strings.NewReader(listEventStream))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var out strings.Builder
+	printApplications(&out, result.Applications)
+
+	expected := "KEY                        NAME        VERSION          STATE     LOCAL\n" +
+		"com.enonic.app.superhero   Superhero   2.0.5            started   \n" +
+		"com.enonic.app.local                   1.0.0-SNAPSHOT   stopped   yes\n"
+
+	if out.String() != expected {
+		t.Errorf("unexpected table:\n%s\nwant:\n%s", out.String(), expected)
+	}
+}
+
+func TestPrintApplicationsEmpty(t *testing.T) {
+	var out strings.Builder
+	printApplications(&out, nil)
+
+	if out.String() != "" {
+		t.Errorf("expected nothing on stdout, got %q", out.String())
+	}
+}

--- a/internal/app/commands/app/list_test.go
+++ b/internal/app/commands/app/list_test.go
@@ -91,3 +91,22 @@ func TestReadApplicationListInvalidJson(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 }
+
+// XP 7 may send explicit nulls where XP 8 omits the field
+func TestReadApplicationListWithNullFields(t *testing.T) {
+	stream := `event: list
+data: {"applications":[{"key":"com.enonic.app.local","version":"1.0.0","state":"stopped","local":true,"displayName":null,"url":null,"vendorName":null,"vendorUrl":null,"minSystemVersion":null,"maxSystemVersion":null,"modifiedTime":null}]}
+
+`
+	result, err := readApplicationList(strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Applications) != 1 {
+		t.Fatalf("expected 1 application, got %d", len(result.Applications))
+	}
+	app := result.Applications[0]
+	if app.Key != "com.enonic.app.local" || app.DisplayName != "" || !app.ModifiedTime.IsZero() {
+		t.Errorf("unexpected application: %+v", app)
+	}
+}

--- a/internal/app/commands/app/list_test.go
+++ b/internal/app/commands/app/list_test.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+const listEventStream = `id: 018f-1
+event: list
+data: {"applications":[{"displayName":"Superhero","key":"com.enonic.app.superhero","local":false,"maxSystemVersion":"8","minSystemVersion":"7.7.0","modifiedTime":"2026-08-17T10:00:00.000Z","state":"started","url":"https://market.enonic.com/","vendorName":"Enonic AS","vendorUrl":"https://enonic.com","version":"2.0.5"},{"key":"com.enonic.app.local","local":true,"modifiedTime":"2026-08-17T11:00:00.000Z","state":"stopped","version":"1.0.0-SNAPSHOT"}]}
+
+`
+
+func TestReadApplicationList(t *testing.T) {
+	result, err := readApplicationList(strings.NewReader(listEventStream))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Applications) != 2 {
+		t.Fatalf("expected 2 applications, got %d", len(result.Applications))
+	}
+
+	superhero := result.Applications[0]
+	if superhero.Key != "com.enonic.app.superhero" {
+		t.Errorf("unexpected key: %q", superhero.Key)
+	}
+	if superhero.DisplayName != "Superhero" {
+		t.Errorf("unexpected display name: %q", superhero.DisplayName)
+	}
+	if superhero.Version != "2.0.5" {
+		t.Errorf("unexpected version: %q", superhero.Version)
+	}
+	if superhero.State != "started" {
+		t.Errorf("unexpected state: %q", superhero.State)
+	}
+	if superhero.Local {
+		t.Error("expected superhero not to be local")
+	}
+	if superhero.MinSystemVersion != "7.7.0" || superhero.MaxSystemVersion != "8" {
+		t.Errorf("unexpected system versions: %q - %q", superhero.MinSystemVersion, superhero.MaxSystemVersion)
+	}
+	if superhero.VendorName != "Enonic AS" || superhero.VendorUrl != "https://enonic.com" {
+		t.Errorf("unexpected vendor: %q %q", superhero.VendorName, superhero.VendorUrl)
+	}
+	if superhero.ModifiedTime.IsZero() {
+		t.Error("expected modified time to be parsed")
+	}
+
+	// XP omits fields that have no value, they must not break parsing
+	local := result.Applications[1]
+	if !local.Local || local.State != "stopped" || local.DisplayName != "" {
+		t.Errorf("unexpected local application: %+v", local)
+	}
+}
+
+func TestReadApplicationListSkipsOtherEvents(t *testing.T) {
+	stream := "event: state\ndata: {\"key\":\"com.enonic.app.superhero\"}\n\n" + listEventStream
+
+	result, err := readApplicationList(strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Applications) != 2 {
+		t.Errorf("expected 2 applications, got %d", len(result.Applications))
+	}
+}
+
+func TestReadApplicationListEmpty(t *testing.T) {
+	result, err := readApplicationList(strings.NewReader("event: list\ndata: {\"applications\":[]}\n\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Applications) != 0 {
+		t.Errorf("expected no applications, got %d", len(result.Applications))
+	}
+}
+
+func TestReadApplicationListWithoutListEvent(t *testing.T) {
+	_, err := readApplicationList(strings.NewReader("event: state\ndata: {}\n\n"))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "list") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestReadApplicationListInvalidJson(t *testing.T) {
+	if _, err := readApplicationList(strings.NewReader("event: list\ndata: not json\n\n")); err == nil {
+		t.Fatal("expected an error")
+	}
+}

--- a/internal/app/commands/commands.go
+++ b/internal/app/commands/commands.go
@@ -36,7 +36,7 @@ func All() []cli.Command {
 		export.Import,
 		{
 			Name:        "app",
-			Usage:       "Install, stop and start applications",
+			Usage:       "Install, list, stop and start applications",
 			HelpName:    "Application",
 			Subcommands: app.All(),
 		},

--- a/internal/app/commands/common/sse.go
+++ b/internal/app/commands/common/sse.go
@@ -10,14 +10,13 @@ const SSE_CONTENT_TYPE = "text/event-stream"
 
 const SSE_DEFAULT_EVENT = "message"
 
-// SseEvent is a single event dispatched by a Server-Sent Events stream.
 type SseEvent struct {
 	Id    string
 	Event string
 	Data  string
 }
 
-// SseReader parses a Server-Sent Events stream one event at a time.
+// bufio.Reader and not Scanner: a data line can exceed Scanner's 64KB token limit
 type SseReader struct {
 	reader *bufio.Reader
 }
@@ -26,9 +25,6 @@ func NewSseReader(stream io.Reader) *SseReader {
 	return &SseReader{reader: bufio.NewReader(stream)}
 }
 
-// Next reads the stream until the next event is dispatched. Comments, unknown
-// fields and events without data are skipped, as is an incomplete event at the
-// end of the stream. Returns io.EOF once the stream has no more events.
 func (r *SseReader) Next() (*SseEvent, error) {
 	var (
 		id, event string
@@ -44,7 +40,6 @@ func (r *SseReader) Next() (*SseEvent, error) {
 
 		switch {
 		case line == "":
-			// a blank line dispatches the event, unless there is nothing to dispatch
 			if len(data) > 0 {
 				if event == "" {
 					event = SSE_DEFAULT_EVENT
@@ -52,10 +47,7 @@ func (r *SseReader) Next() (*SseEvent, error) {
 				return &SseEvent{Id: id, Event: event, Data: strings.Join(data, "\n")}, nil
 			}
 			id, event, data = "", "", nil
-		case strings.HasPrefix(line, ":"):
-			// comment
-		default:
-			// "retry" and unknown fields are ignored
+		case !strings.HasPrefix(line, ":"):
 			switch name, value := splitSseField(line); name {
 			case "id":
 				id = value

--- a/internal/app/commands/common/sse.go
+++ b/internal/app/commands/common/sse.go
@@ -1,0 +1,81 @@
+package common
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+const SSE_CONTENT_TYPE = "text/event-stream"
+
+const SSE_DEFAULT_EVENT = "message"
+
+// SseEvent is a single event dispatched by a Server-Sent Events stream.
+type SseEvent struct {
+	Id    string
+	Event string
+	Data  string
+}
+
+// SseReader parses a Server-Sent Events stream one event at a time.
+type SseReader struct {
+	reader *bufio.Reader
+}
+
+func NewSseReader(stream io.Reader) *SseReader {
+	return &SseReader{reader: bufio.NewReader(stream)}
+}
+
+// Next reads the stream until the next event is dispatched. Comments, unknown
+// fields and events without data are skipped, as is an incomplete event at the
+// end of the stream. Returns io.EOF once the stream has no more events.
+func (r *SseReader) Next() (*SseEvent, error) {
+	var (
+		id, event string
+		data      []string
+	)
+
+	for {
+		line, err := r.reader.ReadString('\n')
+		if line == "" && err != nil {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+
+		switch {
+		case line == "":
+			// a blank line dispatches the event, unless there is nothing to dispatch
+			if len(data) > 0 {
+				if event == "" {
+					event = SSE_DEFAULT_EVENT
+				}
+				return &SseEvent{Id: id, Event: event, Data: strings.Join(data, "\n")}, nil
+			}
+			id, event, data = "", "", nil
+		case strings.HasPrefix(line, ":"):
+			// comment
+		default:
+			// "retry" and unknown fields are ignored
+			switch name, value := splitSseField(line); name {
+			case "id":
+				id = value
+			case "event":
+				event = value
+			case "data":
+				data = append(data, value)
+			}
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+func splitSseField(line string) (string, string) {
+	name, value, found := strings.Cut(line, ":")
+	if !found {
+		return name, ""
+	}
+	return name, strings.TrimPrefix(value, " ")
+}

--- a/internal/app/commands/common/sse.go
+++ b/internal/app/commands/common/sse.go
@@ -19,6 +19,8 @@ type SseEvent struct {
 // bufio.Reader and not Scanner: a data line can exceed Scanner's 64KB token limit
 type SseReader struct {
 	reader *bufio.Reader
+	// the spec keeps the last event id across events, only the server can change it
+	lastEventId string
 }
 
 func NewSseReader(stream io.Reader) *SseReader {
@@ -27,8 +29,8 @@ func NewSseReader(stream io.Reader) *SseReader {
 
 func (r *SseReader) Next() (*SseEvent, error) {
 	var (
-		id, event string
-		data      []string
+		event string
+		data  []string
 	)
 
 	for {
@@ -44,13 +46,13 @@ func (r *SseReader) Next() (*SseEvent, error) {
 				if event == "" {
 					event = SSE_DEFAULT_EVENT
 				}
-				return &SseEvent{Id: id, Event: event, Data: strings.Join(data, "\n")}, nil
+				return &SseEvent{Id: r.lastEventId, Event: event, Data: strings.Join(data, "\n")}, nil
 			}
-			id, event, data = "", "", nil
+			event, data = "", nil
 		case !strings.HasPrefix(line, ":"):
 			switch name, value := splitSseField(line); name {
 			case "id":
-				id = value
+				r.lastEventId = value
 			case "event":
 				event = value
 			case "data":

--- a/internal/app/commands/common/sse_test.go
+++ b/internal/app/commands/common/sse_test.go
@@ -1,0 +1,107 @@
+package common
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestSseReaderParsesEvents(t *testing.T) {
+	stream := "id: 1\nevent: list\ndata: {\"applications\":[]}\n\n" +
+		"id: 2\nevent: state\ndata: {\"key\":\"com.enonic.app.superhero\"}\n\n"
+
+	reader := NewSseReader(strings.NewReader(stream))
+
+	first, err := reader.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if first.Id != "1" || first.Event != "list" || first.Data != `{"applications":[]}` {
+		t.Errorf("unexpected first event: %+v", first)
+	}
+
+	second, err := reader.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if second.Id != "2" || second.Event != "state" || second.Data != `{"key":"com.enonic.app.superhero"}` {
+		t.Errorf("unexpected second event: %+v", second)
+	}
+
+	if _, err = reader.Next(); err != io.EOF {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+}
+
+func TestSseReaderSkipsCommentsAndUnknownFields(t *testing.T) {
+	stream := ": ping\n\nretry: 3000\nnonsense: value\nevent: list\ndata: {}\n\n"
+
+	event, err := NewSseReader(strings.NewReader(stream)).Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Event != "list" || event.Data != "{}" {
+		t.Errorf("unexpected event: %+v", event)
+	}
+}
+
+func TestSseReaderJoinsMultilineData(t *testing.T) {
+	stream := "event: list\ndata: {\ndata: }\n\n"
+
+	event, err := NewSseReader(strings.NewReader(stream)).Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Data != "{\n}" {
+		t.Errorf("unexpected data: %q", event.Data)
+	}
+}
+
+func TestSseReaderDefaultsEventName(t *testing.T) {
+	event, err := NewSseReader(strings.NewReader("data: hello\n\n")).Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Event != SSE_DEFAULT_EVENT {
+		t.Errorf("expected %q, got %q", SSE_DEFAULT_EVENT, event.Event)
+	}
+}
+
+func TestSseReaderHandlesCarriageReturns(t *testing.T) {
+	event, err := NewSseReader(strings.NewReader("event: list\r\ndata: {}\r\n\r\n")).Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Event != "list" || event.Data != "{}" {
+		t.Errorf("unexpected event: %+v", event)
+	}
+}
+
+func TestSseReaderFieldWithoutSpaceAndWithoutValue(t *testing.T) {
+	event, err := NewSseReader(strings.NewReader("event:list\ndata:{}\nid\n\n")).Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Event != "list" || event.Data != "{}" || event.Id != "" {
+		t.Errorf("unexpected event: %+v", event)
+	}
+}
+
+func TestSseReaderDiscardsIncompleteEvent(t *testing.T) {
+	// no blank line at the end of the stream, so the event is never dispatched
+	if _, err := NewSseReader(strings.NewReader("event: list\ndata: {}\n")).Next(); err != io.EOF {
+		t.Errorf("expected io.EOF, got %v", err)
+	}
+}
+
+func TestSseReaderReadsDataLongerThanScannerLimit(t *testing.T) {
+	payload := strings.Repeat("a", 128*1024)
+
+	event, err := NewSseReader(strings.NewReader("event: list\ndata: " + payload + "\n\n")).Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Data != payload {
+		t.Errorf("expected %d bytes of data, got %d", len(payload), len(event.Data))
+	}
+}

--- a/internal/app/commands/common/sse_test.go
+++ b/internal/app/commands/common/sse_test.go
@@ -105,3 +105,22 @@ func TestSseReaderReadsDataLongerThanScannerLimit(t *testing.T) {
 		t.Errorf("expected %d bytes of data, got %d", len(payload), len(event.Data))
 	}
 }
+
+func TestSseReaderKeepsLastEventIdAcrossEvents(t *testing.T) {
+	stream := "id: 1\nevent: list\ndata: a\n\n" + // id set
+		"event: state\ndata: b\n\n" + // no id, keeps 1
+		"id: 2\nevent: state\ndata: c\n\n" + // id updated
+		"id\nevent: state\ndata: d\n\n" // empty id resets it
+
+	reader := NewSseReader(strings.NewReader(stream))
+
+	for _, expected := range []string{"1", "1", "2", ""} {
+		event, err := reader.Next()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if event.Id != expected {
+			t.Errorf("data %q: expected id %q, got %q", event.Data, expected, event.Id)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds an `enonic app list` command that shows the applications installed on the running XP instance.

XP has no plain endpoint that returns the installed applications — they are only published as the first `list` event on the app events SSE stream — so this also adds a small reusable SSE parser.

Closes #681

## Key Changes

- **SSE stream parser** (`internal/app/commands/common/sse.go`):
  - `SseReader.Next()` parses an event stream following the WHATWG rules: field/value splitting, multi-line `data` joining, comments and unknown fields ignored, incomplete trailing events discarded, and the last event id carried across events that omit `id:`
  - Built on `bufio.Reader` rather than `bufio.Scanner`, because a single `data:` line can exceed Scanner's 64KB token limit
  - Lives in `common` so other commands can reuse it

- **New `app list` command** (`internal/app/commands/app/list.go`):
  - `enonic app list` (alias `app ls`) opens `app/events` on the active remote, reads the first `list` event and closes the connection without waiting for the long-lived stream
  - Prints an aligned table by default (`KEY` / `NAME` / `VERSION` / `STATE` / `LOCAL`), consistent with `remote list` and `sandbox list`
  - `--json` prints every field XP reports, for scripting
  - Applications are sorted by key, so the output is stable between runs
  - The table goes to stdout and progress messages to stderr, so `enonic app list 2>/dev/null` pipes cleanly into other tools

- **Documentation** (`docs/xp.adoc`):
  - New `List` section with options, a table example, a `--json` example and the minimum XP version

- **Command registration** (`internal/app/commands/app/app.go`, `internal/app/commands/commands.go`):
  - Registered `List` in the app command group and updated the group usage text

## Minimum XP version

**XP 7.6 or later.** The endpoint was introduced in 7.6 as `SseEntryPoint` and later folded into `ApplicationResource` in 8.x. The path, the `list` event name and the payload field names are unchanged from 7.6 through 8.x, so no compatibility branch is needed and `--compat 7` does not apply to this command.

## Tests

17 unit tests, all passing:

- 9 for the SSE parser — multi-line `data`, comments and unknown fields, CRLF line endings, default event name, last-event-id persistence, payloads larger than Scanner's 64KB limit, and incomplete trailing events
- 8 for the list parsing and table rendering — empty lists, streams whose `list` event is preceded by other events, missing `list` event, invalid JSON, table alignment, and the explicit `null` fields XP 7 can send where XP 8 omits them

Verified end to end against a stub SSE server: correct `Accept: text/event-stream` and credentials on the wire, and the command returns immediately rather than blocking on a stream the server holds open.

https://claude.ai/code/session_01XrZk5SYGtwSkqUZkqZZRE5