### PR TITLE
Remove --xsl-source and --xsl-param from enonic import #694

### DIFF
--- a/docs/xp.adoc
+++ b/docs/xp.adoc
@@ -387,8 +387,6 @@ $ enonic import -h
   OPTIONS:
      -t value                A named export to import.
      --path value            Target path for import. Format: <repo-name>:<branch-name>:<node-path> e.g. 'cms-repo:draft:/'
-     --xsl-source value      Path to xsl file (relative to <XP_HOME>/data/export) for applying transformations to node.xml before importing.
-     --xsl-param value       Parameters to pass to the XSL transformations before importing nodes. Format: <parameter-name>=<parameter-value> e.g. 'applicationId=com.enonic.myapp'
      --skip-ids              Flag to skips ids when importing
      --skip-permissions      Flag to skips permissions when importing
      --dry                   Show the result without making actual changes. Only effective in compat mode (XP 7).
@@ -406,13 +404,6 @@ include::.snippets.adoc[tag=credentials-flags-notes]
 ----
 $ enonic import --cred-file path\to\cred-file.json -t myExport --path cms-repo:draft:/some-content
 ----
-
-[TIP]
-====
-An XSL file and a set of name=value parameters can be optionally passed for applying transformations to each node.xml file, before importing it.
-
-This option could for example be used for renaming types or fields. The .xsl file must be located in the `$XP_HOME/data/export` directory.
-====
 
 
 == App

--- a/internal/app/commands/export/export_test.go
+++ b/internal/app/commands/export/export_test.go
@@ -35,7 +35,6 @@ func newCtx(t *testing.T, compat string, bools map[string]bool) *cli.Context {
 	fs.String("compat", "", "")
 	fs.String("t", "", "")
 	fs.String("path", "", "")
-	fs.String("xsl-source", "", "")
 	for _, name := range []string{"skip-ids", "skip-versions", "skip-permissions", "dry"} {
 		fs.Bool(name, false, "")
 	}
@@ -107,11 +106,10 @@ func TestCreateNewRequest_CompatFlags(t *testing.T) {
 	}
 }
 
-// XP 8 ImportNodesRequestJson dropped dryRun but kept importWithIds,
-// importWithPermissions, xslSource and xslParams.
+// XP 8 ImportNodesRequestJson dropped dryRun but kept importWithIds and
+// importWithPermissions.
 func TestCreateLoadRequest_XP8OmitsDryRun(t *testing.T) {
 	isolateEnonicHome(t)
-	xslParams = nil
 	c := newCtx(t, "", map[string]bool{"skip-ids": true, "dry": true})
 	params := decodeJSONBody(t, createLoadRequest(c).Body)
 
@@ -123,7 +121,6 @@ func TestCreateLoadRequest_XP8OmitsDryRun(t *testing.T) {
 
 func TestCreateLoadRequest_CompatIncludesDryRun(t *testing.T) {
 	isolateEnonicHome(t)
-	xslParams = nil
 	c := newCtx(t, "7", map[string]bool{"dry": true})
 	params := decodeJSONBody(t, createLoadRequest(c).Body)
 

--- a/internal/app/commands/export/import.go
+++ b/internal/app/commands/export/import.go
@@ -8,13 +8,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
-
-var xslParams map[string]string
 
 var Import = cli.Command{
 	Name:  "import",
@@ -27,14 +23,6 @@ var Import = cli.Command{
 		cli.StringFlag{
 			Name:  "path",
 			Usage: "Target path for import. Format: <repo-name>:<branch-name>:<node-path> e.g. 'cms-repo:draft:/'",
-		},
-		cli.StringFlag{
-			Name:  "xsl-source",
-			Usage: "Path to xsl file (relative to <XP_HOME>/data/export) for applying transformations to node.xml before importing.",
-		},
-		cli.StringSliceFlag{
-			Name:  "xsl-param",
-			Usage: "Parameters to pass to the XSL transformations before importing nodes. Format: <parameter-name>=<parameter-value> e.g. 'applicationId=com.enonic.myapp'",
 		},
 		cli.BoolFlag{
 			Name:  "skip-ids",
@@ -56,7 +44,6 @@ var Import = cli.Command{
 
 		ensureNameFlag(c)
 		ensurePathFlag(c)
-		ensureXSLParamsFlagFormat(c)
 
 		req := createLoadRequest(c)
 
@@ -75,31 +62,6 @@ var Import = cli.Command{
 	},
 }
 
-func ensureXSLParamsFlagFormat(c *cli.Context) {
-	params := c.StringSlice("xsl-param")
-	force := common.IsForceMode(c)
-	xslParams = make(map[string]string)
-
-	var splitParam []string
-	validator := func(val interface{}) error {
-		str := val.(string)
-		splitParam = strings.Split(str, "=")
-		if len(strings.TrimSpace(str)) != 0 && len(splitParam) != 2 {
-			if force {
-				fmt.Fprintf(os.Stderr, "Xsl parameter '%s' must have the following format <parameter-name>=<parameter-value>\n", str)
-				os.Exit(1)
-			}
-			return errors.Errorf("Xsl parameter '%s' must have the following format <parameter-name>=<parameter-value>: ", str)
-		}
-		return nil
-	}
-
-	for _, param := range params {
-		param = util.PromptString(fmt.Sprintf("Xsl parameter '%s'", param), param, "", validator)
-		xslParams[splitParam[0]] = splitParam[1]
-	}
-}
-
 func createLoadRequest(c *cli.Context) *http.Request {
 	body := new(bytes.Buffer)
 	params := map[string]interface{}{
@@ -107,12 +69,6 @@ func createLoadRequest(c *cli.Context) *http.Request {
 		"targetRepoPath": c.String("path"),
 	}
 
-	if xslSource := c.String("xsl-source"); xslSource != "" {
-		params["xslSource"] = xslSource
-	}
-	if len(xslParams) > 0 {
-		params["xslParams"] = xslParams
-	}
 	params["importWithIds"] = !c.Bool("skip-ids")
 
 	params["importWithPermissions"] = !c.Bool("skip-permissions")


### PR DESCRIPTION
Fixes #694.

XP never applied an XSLT stylesheet given as a file name in `$XP_HOME/data/export`, and enonic/xp#12316 deprecates and ignores the `xslSource` and `xslParams` fields on `POST /api/repo/import`. A stylesheet read from disk has no provenance; transformations belong in application code via `lib-export`'s `importNodes({ xslt: resolve(...) })`.

## Changes

* `internal/app/commands/export/import.go`: drop the `xsl-source` and `xsl-param` flags, `ensureXSLParamsFlagFormat`, the package-level `xslParams`, and the request body keys.
* `internal/app/commands/export/export_test.go`: remove the flag from the test context and the `xslParams` resets.
* `docs/xp.adoc`: remove the two flag lines and the XSL tip from the import section.

`go build ./...`, `go vet` and `go test` on the export package pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKAAx35EQRaygmqUq99sib

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKAAx35EQRaygmqUq99sib)_